### PR TITLE
Feat/add ci tests like aks store demo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,79 @@
+name: ci
+permissions:
+  contents: read
+  id-token: write
+on:
+  push:
+jobs:
+  score-validate:
+    strategy:
+      matrix:
+        apps:
+          - database
+          - reference-data
+          - trade-feed
+          - people-service
+          - account-service
+          - position-service
+          - trade-processor
+          - trade-service
+          - web-frontend
+          - ingress
+      fail-fast: false
+    runs-on: ubuntu-24.04
+    env:
+      HUMCTL_VERSION: '*'
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+      - name: install humctl
+        uses: humanitec/setup-cli-action@v1
+        with:
+          version: ${{ env.HUMCTL_VERSION }}
+      - name: humctl score validate
+        run: |
+          humctl score validate apps/${{ matrix.apps }}/score.yaml \
+              --strict \
+              --local
+  score-compose:
+    runs-on: ubuntu-24.04
+    env:
+      SCORE_COMPOSE_VERSION: 'latest'
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+      - name: install score-compose
+        uses: score-spec/setup-score@v3
+        with:
+          file: score-compose
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ env.SCORE_COMPOSE_VERSION }}
+      - name: make compose-test
+        run: |
+          make compose-test
+  score-k8s:
+    runs-on: ubuntu-24.04
+    env:
+      SCORE_K8S_VERSION: 'latest'
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+      - name: install score-k8s
+        uses: score-spec/setup-score@v3
+        with:
+          file: score-k8s
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ env.SCORE_K8S_VERSION }}
+      - name: make kind-create-cluster
+        run: |
+          make kind-create-cluster
+      - name: make k8s-up
+        id: k8s-up
+        run: |
+          make k8s-up
+      - name: catch k8s-up errors
+        if: ${{ failure() && steps.k8s-up.outcome == 'failure' }}
+        run: |
+          kubectl get events
+          kubectl logs \
+              -l app.kubernetes.io/name=store-admin

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,18 +8,7 @@ jobs:
   score-validate:
     strategy:
       matrix:
-        apps:
-          - database
-          - reference-data
-          - trade-feed
-          - people-service
-          - account-service
-          - position-service
-          - trade-processor
-          - trade-service
-          - web-frontend
-          - ingress
-      fail-fast: false
+        apps: ["database", "reference-data", "trade-feed", "people-service", "account-service", "position-service", "trade-processor", "trade-service", "web-frontend", "ingress"]
     runs-on: ubuntu-24.04
     env:
       HUMCTL_VERSION: '*'


### PR DESCRIPTION
## Description
  Adds CI tests for the score deploy configuration, ensuring that the score.deploy.yaml file is correctly set up and validated against the specFiles.
  
  ## Changes Made
  - Created workflow file \`ci.yaml\` in the .github/workflows directory
  - Added apps in strategy matrix (based on recommended order by TraderX demo) to include all necessary applications for testing
    - Validation passed for all apps ( but not compose and k8s tests)